### PR TITLE
Small locale awareness

### DIFF
--- a/etc/environment.sh
+++ b/etc/environment.sh
@@ -3,7 +3,11 @@
 export ZOE_SERVER_HOST=localhost
 export ZOE_SERVER_PORT=30000
 
-# Paramters for Google Talk
+# Preferred locale for Zoe
+# Consists of a two char code such as: en (English), es (Spanish), etc.
+export ZOE_LOCALE="es"
+
+# Parameters for Google Talk
 export zoe_jabber_host="talk.google.com"
 export zoe_jabber_port="5222"
 export zoe_jabber_user="..."

--- a/etc/zoe-users.conf
+++ b/etc/zoe-users.conf
@@ -6,6 +6,7 @@ jabber = your_jabber_id@wherever.com
 mail = your_email@address.com
 alias = god master
 tg = user#xxx
+locale = preferred locale code: en, es, etc.
 
 [group admins]
 members = admin


### PR DESCRIPTION
Added a small environment variable and user setting for locale awareness.

This way, agents that support feedback messages in several languages may be able to check the preferred locale for an user or use Zoe's as a fallback.